### PR TITLE
Run TimezoneFinder.timezone_at & imports in executor

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,7 +10,7 @@ jobs:
     name: With hassfest
     steps:
     - name: 📥 Checkout the repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: 🏃 Hassfest validation
       uses: "home-assistant/actions/hassfest@master"

--- a/custom_components/entity_tz/__init__.py
+++ b/custom_components/entity_tz/__init__.py
@@ -63,8 +63,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     etzd.tz_users[entry.entry_id] = 0
 
     loc_cache_size = len(etzd.loc_users) * LOC_CACHE_PER_CONFIG
-    _get_location._LRUCacheWrapper__maxsize = max(  # type: ignore[attr-defined] # pylint: disable=protected-access
-        _get_location._LRUCacheWrapper__maxsize, loc_cache_size  # type: ignore[attr-defined] # pylint: disable=protected-access
+    _get_location._LRUCacheWrapper__maxsize = max(  # pylint: disable=protected-access
+        _get_location._LRUCacheWrapper__maxsize,  # pylint: disable=protected-access
+        loc_cache_size,
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -98,7 +99,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             else:
                 entity_loc = None
             if etzd.tz_users[entry.entry_id]:
-                entity_tz = get_tz(hass, new_state)
+                entity_tz = await get_tz(hass, new_state)
             else:
                 entity_tz = None
             async_dispatcher_send(hass, signal(entry), entity_loc, entity_tz)

--- a/custom_components/entity_tz/manifest.json
+++ b/custom_components/entity_tz/manifest.json
@@ -5,6 +5,7 @@
   "config_flow": true,
   "dependencies": ["zone"],
   "documentation": "https://github.com/pnbruckner/ha-entity-tz/blob/1.1.0/README.md",
+  "import_executor": true,
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/pnbruckner/ha-entity-tz/issues",
   "loggers": ["geopy"],


### PR DESCRIPTION
TimezoneFinder.timezone_at can, in some cases, do file I/O, so call it in an executor. Also, there are some indications that importing this integration can take too long, so do that in an executor also by adding `"import_executor": true` to manifest.json.

Resolves #7.